### PR TITLE
Add blog post on AI authorship and ownership

### DIFF
--- a/src/content/posts/ai-authorship-ownership.md
+++ b/src/content/posts/ai-authorship-ownership.md
@@ -1,0 +1,45 @@
+---
+title: Authorship in the Age of AI Agents
+subtitle: Ownership isn't about generation—it's about the moment you put your name on it
+date: 2025-01-10
+type: thinking
+tags:
+  - working with AI
+  - software development
+  - authorship
+description: On the evolving nature of authorship when AI does the generating and you do the directing.
+---
+
+I've been thinking about authorship and ownership when it comes to using generative AI—specifically in a software development context. And it occurred to me there's a parallel concept that doesn't get enough attention: the intentionality we bring when designing our agents, skills, and prompts.
+
+## The Ideal Developer You Can't Quite Be
+
+As developers, there's always a gap between who we are and who we know we should be. The ideal version has memorized all the best practices. They understand every nuance of accessibility, recognize anti-patterns on sight, and can reason about systems design without breaking a sweat.
+
+But we're human. There are limits to what we can keep in mind at once.
+
+A good example is PR review. You notice more when you're primed to see it—when experience has wired certain patterns into your brain. Experience is like RAM extension for your attention. But we're not always at our sharpest. We don't catch everything, every time.
+
+## Your Agents Are Your Rubrics
+
+This is where AI comes back into the picture. Think of your skills and agents as rubrics you write out in detail—not just defining your ideal developer mind, but doing so in a living, growing document. These become the team you deploy when the task is at hand.
+
+If I build a PR review agent skill with my carefully considered principles baked in, I'm offloading work while still directing it. It's like deploying a small army of junior developers, each following my core concerns to the letter.
+
+## The Publishing Moment
+
+This brings me back to authorship. The reviews I make, the comments I write, even the code and documentation I produce—much of it may be generated. Directed by me, but generated nonetheless.
+
+And yet, authorship falls on the final publishing moment. When I put my name on something.
+
+When that happens, I should have full comprehension of it. Full agreement with it. It should be something I can stand behind and defend—something I would actually take credit for in front of others.
+
+I don't want to waste anyone's time or push out slop. That should be apparent in anything I publish, regardless of how it was made.
+
+## Not Pure, But Evolved
+
+I know this isn't "pure" authorship in the traditional sense. But it is a version of authorship, evolving to fit new tools and workflows—at least in this software development context.
+
+The bar remains the same: Can I understand it? Can I defend it? Would I put my name on it?
+
+If yes, it's mine.


### PR DESCRIPTION
Explores the evolving nature of authorship in software development when working with AI agents—arguing that ownership lies in the publishing moment when you put your name on something you fully understand and can defend.